### PR TITLE
166152319 Get all information for an exercise

### DIFF
--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -25,13 +25,12 @@ from wger.exercises.models import (
 )
 
 
-class ExerciseSerializer(serializers.ModelSerializer):
+class MuscleSerializer(serializers.ModelSerializer):
     '''
-    Exercise serializer
+    Muscle serializer
     '''
-
     class Meta:
-        model = Exercise
+        model = Muscle
         fields = '__all__'
 
 
@@ -44,15 +43,6 @@ class EquipmentSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-class ExerciseCategorySerializer(serializers.ModelSerializer):
-    '''
-    ExerciseCategory serializer
-    '''
-    class Meta:
-        model = ExerciseCategory
-        fields = '__all__'
-
-
 class ExerciseImageSerializer(serializers.ModelSerializer):
     '''
     ExerciseImage serializer
@@ -62,19 +52,44 @@ class ExerciseImageSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+class ExerciseSerializer(serializers.ModelSerializer):
+    '''
+    Exercise serializer
+    '''
+    category = serializers.SerializerMethodField()
+    language = serializers.SerializerMethodField()
+    license = serializers.SerializerMethodField()
+    muscles = MuscleSerializer(many=True, read_only=True, required=False)
+    muscles_secondary = MuscleSerializer(many=True, read_only=True, required=False)
+    equipment = EquipmentSerializer(many=True, read_only=True, required=False)
+
+    class Meta:
+        model = Exercise
+        fields = '__all__'
+
+    def get_category(self, obj):
+        return obj.category.name
+
+    def get_language(self, obj):
+        return obj.language.full_name
+
+    def get_license(self, obj):
+        return obj.license.short_name
+
+
+class ExerciseCategorySerializer(serializers.ModelSerializer):
+    '''
+    ExerciseCategory serializer
+    '''
+    class Meta:
+        model = ExerciseCategory
+        fields = '__all__'
+
+
 class ExerciseCommentSerializer(serializers.ModelSerializer):
     '''
     ExerciseComment serializer
     '''
     class Meta:
         model = ExerciseComment
-        fields = '__all__'
-
-
-class MuscleSerializer(serializers.ModelSerializer):
-    '''
-    Muscle serializer
-    '''
-    class Meta:
-        model = Muscle
         fields = '__all__'

--- a/wger/exercises/tests/test_single_exercise_info.py
+++ b/wger/exercises/tests/test_single_exercise_info.py
@@ -1,0 +1,16 @@
+from wger.core.tests.api_base_test import (ApiGetTestCase, ApiBaseTestCase)
+from wger.core.tests.base_testcase import WorkoutManagerTestCase
+from rest_framework import status
+from wger.exercises.models import Exercise
+
+
+class TestExerciseInfo(ApiBaseTestCase, ApiGetTestCase, WorkoutManagerTestCase):
+
+    pk = 1
+    resource = Exercise
+    private_resource = False
+
+    def test_getting_non_existing_exercise(self):
+        url2 = 'api/v2/exercise/1000000'
+        response = self.client.get(url2)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
#### Title
All information for a single exercise should be displayed when a user hits the endpoint 

#### Description
This feature allows a client to view only the information for particular information and adds one endpoint for the functionality.

To test the functionality, checkout to the the branch `feature/166152319-get-an-exercise-info`, run `python manage.py runserver` and on Postman, send a GET request to `http://127.0.0.1:8000/api/v2/exercise/exercise_id`
<img width="1098" alt="Screenshot 2019-06-06 at 08 50 35" src="https://user-images.githubusercontent.com/40719885/59009976-55c48780-8838-11e9-90b0-ddb24b6d6892.png">


#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue) 

- [x] New feature (non-breaking change which adds functionality) 


- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) 


- [ ] This change requires a documentation update


#### How Has This Been Tested?
- [x] Unit tests

#### Checklist:
- [x] Create a test for getting an exercises info
- [x] Create an endpoint for getting a single exercises info
- [x] Refactor tests to pass with new functionality

#### PT stories
[#166152319](https://www.pivotaltracker.com/story/show/166152319)