### PR TITLE
166535884 Catches blank requests sent to nutrition app

### DIFF
--- a/wger/nutrition/api/views.py
+++ b/wger/nutrition/api/views.py
@@ -217,23 +217,11 @@ class MealViewSet(WgerOwnerObjectModelViewSet):
         '''
         return Meal.objects.filter(plan__user=self.request.user)
 
-    def perform_create(self, serializer):
-        '''
-        Set the order
-        '''
-        serializer.save(order=1)
-
     def create(self, request):
-        plan_id = request.data.get('plan', '')
-        try:
-            NutritionPlan.objects.get(id=plan_id)
-            serializer = self.serializer_class(
-                data=request.data, context={'request': request}
-            )
-            serializer.is_valid(raise_exception=True)
-        except NutritionPlan.DoesNotExist:
-            return Response({"error": "NutritionPlan with provided id not found"},
-                            status=status.HTTP_404_NOT_FOUND)
+        serializer = self.serializer_class(
+            data=request.data, context={'request': request}
+        )
+        serializer.is_valid(raise_exception=True)
         serializer.save(order=1)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
@@ -270,23 +258,11 @@ class MealItemViewSet(WgerOwnerObjectModelViewSet):
         '''
         return MealItem.objects.filter(meal__plan__user=self.request.user)
 
-    def perform_create(self, serializer, **kwargs):
-        '''
-        Set the order
-        '''
-        serializer.save(order=1)
-
     def create(self, request):
-        meal_id = request.data.get('meal', '')
-        try:
-            Meal.objects.get(id=meal_id)
-            serializer = self.serializer_class(
-                data=request.data, context={'request': request}
-            )
-            serializer.is_valid(raise_exception=True)
-        except Meal.DoesNotExist:
-            return Response({"error": "Meal with provided id not found"},
-                            status=status.HTTP_404_NOT_FOUND)
+        serializer = self.serializer_class(
+            data=request.data, context={'request': request}
+        )
+        serializer.is_valid(raise_exception=True)
         serializer.save(order=1)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 

--- a/wger/nutrition/tests/test_meal.py
+++ b/wger/nutrition/tests/test_meal.py
@@ -143,7 +143,7 @@ class MealApiEdgeTestCase(WorkoutManagerTestCase):
         create_meal = self.client.post('/api/v2/meal/', {
             "plan": 800
         }, format='json')
-        self.assertEqual(create_meal.status_code, 404)
+        self.assertEqual(create_meal.status_code, 400)
 
     def test_create_meal_time_not_provided(self):
         self.user_login("test")

--- a/wger/nutrition/tests/test_meal_item.py
+++ b/wger/nutrition/tests/test_meal_item.py
@@ -99,7 +99,7 @@ class MealItemApiEdgeTestCase(WorkoutManagerTestCase):
             "meal": 190,
             "time": "23:00:00"
         }, format='json')
-        self.assertEqual(create_mealitem.status_code, 404)
+        self.assertEqual(create_mealitem.status_code, 400)
 
     def test_create_mealitem_ingredient_not_provided(self):
         self.user_login("test")


### PR DESCRIPTION
#### Title
Fixes validation of data sent to nutrition API endpoints
#### Description
### Steps to reproduce
1. Send a blank request to meal and mealitem endpoint
2. Catch existence of blank request in meal and mealitem endpoint

### Expected
Catch blank requests sent to API endpoints in nutrition app

### Actual
Throws an internal server error when blank requests are sent to API endpoints in nutrition app


#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue) 

- [ ] New feature (non-breaking change which adds functionality) 


- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) 


- [ ] This change requires a documentation update


#### How Has This Been Tested?
- [x] Unit tests

#### Acceptance Criteria: 
<!-- THis section is applicable to tasks -->
<!-- These should include conditions that must be met for the chore to be accepted. -->

#### Checklist:
- [x] Uses serializers to validate request data in meal endpoint
- [x] Validates request data in mealitem endpoint

#### PT stories
[#166535884](https://www.pivotaltracker.com/story/show/166535884)