### PR TITLE
166152317-List deactivated gym members on gym overview

### DIFF
--- a/wger/gym/managers.py
+++ b/wger/gym/managers.py
@@ -27,7 +27,7 @@ class GymManager(models.Manager):
     Custom query manager for Gyms
     '''
 
-    def get_members(self, gym_pk):
+    def get_members(self, gym_pk, active=1):
         '''
         Returns all members for this gym (i.e non-admin ones)
         '''
@@ -35,7 +35,7 @@ class GymManager(models.Manager):
         perm_gyms = Permission.objects.get(codename='manage_gyms')
         perm_trainer = Permission.objects.get(codename='gym_trainer')
 
-        users = User.objects.filter(userprofile__gym_id=gym_pk)
+        users = User.objects.filter(userprofile__gym_id=gym_pk, is_active=active)
         return users.exclude(Q(groups__permissions=perm_gym)
                              | Q(groups__permissions=perm_gyms)
                              | Q(groups__permissions=perm_trainer)).distinct()

--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -4,7 +4,7 @@
 {% block title %}{{gym}}{% endblock %}
 
 {% block breadcrumbs %}
-    {{ block.super }}
+{{ block.super }}
 
     {% if perms.gym.manage_gyms %}
         {% breadcrumb "Gyms" "gym:gym:list" %}
@@ -14,63 +14,90 @@
 
 
 {% block content %}
-{% if perms.gym.manage_gym or perms.gym.gym_trainer %}
-    {% include 'gym/partial_user_list.html' %}
-{% endif %}
+<div>
+    <ul class="nav nav-tabs" role="tablist">
+        <li role="presentation" class="active">
+            <a href="#active-users" aria-controls="active-users" role="tab" data-toggle="tab">Active Members</a>
+        </li>
+        <li role="presentation" class="">
+            <a href="#deactivated-users" aria-controls="eactivated-users" role="tab" data-toggle="tab">Inactive
+                Members</a>
+        </li>
+    </ul>
+    <div class="clear-fix">
 
+    </div>
+</div>
+<div class="tab-content">
+    <div id="active-users" role="tabpanel" class="tab-pane active">
 
-<h4>{% trans "Administrators and trainers" %}</h4>
-<table class="table table-hover">
-<thead>
-<tr>
-    <th style="width: 10%;">{% trans "ID" %}</th>
-    <th style="width: 40%;">{% trans "Username" %}</th>
-    <th>{% trans "Name" %}</th>
-    {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
-        <th style="text-align: right;">{% trans "Roles" %}</th>
-    {% endif %}
-</tr>
-</thead>
-<tbody>
-{% for current_user in object_list.admins %}
-<tr>
-    <td>
-        {{current_user.obj.pk}}
-    </td>
-    <td>
-        {{current_user.obj}}
-
-        {% if current_user.perms.gym_trainer %}
-            <span class="label label-primary">{% trans "Trainer" %}</span>
+        {% if perms.gym.manage_gym or perms.gym.gym_trainer %}
+        {% include 'gym/partial_user_list.html' with table_id='main_members_list' %}
         {% endif %}
 
-        {% if current_user.perms.manage_gym %}
-            <span class="label label-primary">{% trans "Gym manager" %}</span>
+
+        <h4>{% trans "Administrators and trainers" %}</h4>
+        <table class="table table-hover">
+            <thead>
+                <tr>
+                    <th style="width: 10%;">{% trans "ID" %}</th>
+                    <th style="width: 40%;">{% trans "Username" %}</th>
+                    <th>{% trans "Name" %}</th>
+                    {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
+                        <th style="text-align: right;">{% trans "Roles" %}</th>
+                    {% endif %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for current_user in object_list.admins %}
+                <tr>
+                    <td>
+                        {{current_user.obj.pk}}
+                    </td>
+                    <td>
+                        {{current_user.obj}}
+
+                        {% if current_user.perms.gym_trainer %}
+                        <span class="label label-primary">{% trans "Trainer" %}</span>
+                        {% endif %}
+
+                        {% if current_user.perms.manage_gym %}
+                        <span class="label label-primary">{% trans "Gym manager" %}</span>
+                        {% endif %}
+
+                        {% if current_user.perms.manage_gyms %}
+                        <span class="label label-primary">{% trans "General manager" %}</span>
+                        {% endif %}
+                    </td>
+                    <td>
+                        {{current_user.obj.get_full_name}}
+                    </td>
+
+                    {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
+                    <td style="text-align: right;">
+                        <a href="{% url 'gym:gym:edit-user-permission' current_user.obj.pk %}"
+                            class="btn btn-default btn-xs wger-modal-dialog">
+                            <span class="{% fa_class 'cog' %}"></span>
+                        </a>
+                    </td>
+                    {% endif %}
+                </tr>
+                {% empty %}
+                <tr>
+                    <td colspan="4">{% trans "This gym has no administrators or trainers" %}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <div id="deactivated-users" role="tabpanel" class="tab-pane fade">
+        {% if perms.gym.manage_gym or perms.gym.gym_trainer %}
+        {% include 'gym/partial_user_list.html' with user_table=inactive_users_table table_id='inactive_member_list' %}
         {% endif %}
 
-        {% if current_user.perms.manage_gyms %}
-            <span class="label label-primary">{% trans "General manager" %}</span>
-        {% endif %}
-    </td>
-    <td>
-        {{current_user.obj.get_full_name}}
-    </td>
+    </div>
 
-    {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
-    <td style="text-align: right;">
-        <a href="{% url 'gym:gym:edit-user-permission' current_user.obj.pk %}" class="btn btn-default btn-xs wger-modal-dialog">
-            <span class="{% fa_class 'cog' %}"></span>
-        </a>
-    </td>
-    {% endif %}
-</tr>
-{% empty %}
-<tr>
-    <td colspan="4">{% trans "This gym has no administrators or trainers" %}</td>
-</tr>
-{% endfor %}
-</tbody>
-</table>
+</div>
 {% endblock %}
 
 
@@ -108,9 +135,9 @@
         <td>{% trans "Email" %}</td>
         <td>
             {% if gym.email %}
-                <a href="mailto:{{gym.email}}">{{gym.email}}</a>
+            <a href="mailto:{{gym.email}}">{{gym.email}}</a>
             {% else %}
-                -/-
+            -/-
             {% endif %}
         </td>
     </tr>
@@ -169,7 +196,8 @@
     </button>
     <ul class="dropdown-menu" role="menu">
         <li>
-            <a href="{% url 'gym:admin_config:edit' user.gymadminconfig.id %}" class="wger-modal-dialog">{% trans "Edit"%}</a>
+            <a href="{% url 'gym:admin_config:edit' user.gymadminconfig.id %}"
+                class="wger-modal-dialog">{% trans "Edit"%}</a>
         </li>
     </ul>
 </div>
@@ -180,9 +208,9 @@
         <td>{% trans "Overview of inactive members" %}</td>
         <td style="text-align: right;">
             {% if user.gymadminconfig.overview_inactive %}
-                <span class="{% fa_class 'check' %}"></span>
+            <span class="{% fa_class 'check' %}"></span>
             {% else %}
-                <span class="{% fa_class 'times' %}"></span>
+            <span class="{% fa_class 'times' %}"></span>
             {% endif %}
         </td>
     </tr>
@@ -195,7 +223,7 @@
 {# Contract configuration #}
 {#                        #}
 {% if perms.gym.change_contracttype or perms.gym.change_contractoption %}
-    <h4>{% trans "Contracts" %}</h4>
+<h4>{% trans "Contracts" %}</h4>
 {% endif %}
 {% if perms.gym.change_contracttype %}
 <div class="btn-group pull-right">
@@ -319,8 +347,8 @@
 {#         #}
 {% block options %}
 {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
-    <a href="{% url 'gym:gym:add-user' gym.pk %}" class="btn btn-success btn-sm wger-modal-dialog">
-        {% trans "Add member" %}
-    </a>
+<a href="{% url 'gym:gym:add-user' gym.pk %}" class="btn btn-success btn-sm wger-modal-dialog">
+    {% trans "Add member" %}
+</a>
 {% endif %}
 {% endblock %}

--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -1,54 +1,67 @@
 {% load i18n staticfiles %}
 
-<link rel="stylesheet" type="text/css" href="{% static 'bower_components/datatables/media/css/dataTables.bootstrap.min.css' %}">
-<script src="{% static 'bower_components/datatables/media/js/jquery.dataTables.min.js' %}" ></script>
-<script src="{% static 'bower_components/datatables/media/js/dataTables.bootstrap.min.js' %}" ></script>
-<script>
-$(document).ready( function () {
-    /* Make table sortable */
-    $('#main_member_list').DataTable({
-        paging: false,
-        bFilter: true,
-        bInfo : false
-    });
-});
-</script>
+<link rel="stylesheet" type="text/css"
+    href="{% static 'bower_components/datatables/media/css/dataTables.bootstrap.min.css' %}">
+<script src="{% static 'bower_components/datatables/media/js/jquery.dataTables.min.js' %}"></script>
+<script src="{% static 'bower_components/datatables/media/js/dataTables.bootstrap.min.js' %}"></script>
 
-<table class="table table-hover" id="main_member_list">
-<thead>
-<tr>
-    {% for key in user_table.keys %}
-        <th>{{ key }}</th>
-    {% endfor %}
-</tr>
-</thead>
-<tbody>
-{% for current_user in user_table.users %}
-<tr>
-    <td>
-        {{current_user.obj.pk}}
-    </td>
-    <td>
-        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
-    </td>
-    <td>
-        {{current_user.obj.get_full_name}}
-    </td>
-    <td data-order="{{current_user.last_log|date:'U'}}">
-        {{current_user.last_log|default:'-/-'}}
-    </td>
-    {% if show_gym %}
-    <td>
-        {% if current_user.obj.userprofile.gym_id %}
-            <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
-            {{ current_user.obj.userprofile.gym }}
-            </a>
-        {% else %}
-            -/-
-        {% endif %}
-    </td>
-    {% endif %}
-</tr>
-{% endfor %}
-</tbody>
+<input type="hidden" name="table_id_var" value="{{ table_id }}">
+
+<script>
+    $(document).ready(function () {
+        /* Make table sortable */
+        var tabl_ids = document.getElementsByName("table_id_var");
+        tabl_ids.forEach(element => {
+            tabl_id = '#' + element.value;
+            if (!$.fn.DataTable.isDataTable(tabl_id)) {
+                $(tabl_id).DataTable({
+                    paging: false,
+                    bFilter: true,
+                    bInfo: false
+                });
+            }
+        });
+
+    });
+
+</script>
+<table class="table table-hover" id="{{ table_id }}">
+
+
+    <thead>
+        <tr>
+            {% for key in user_table.keys %}
+            <th>{{ key }}</th>
+            {% endfor %}
+        </tr>
+    </thead>
+    <tbody>
+        {% for current_user in user_table.users %}
+        <tr>
+            <td>
+                {{current_user.obj.pk}}
+            </td>
+            <td>
+                <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+            </td>
+            <td>
+                {{current_user.obj.get_full_name}}
+            </td>
+            <td data-order="{{current_user.last_log|date:'U'}}">
+                {{current_user.last_log|default:'-/-'}}
+            </td>
+            {% if show_gym %}
+            <td>
+                {% if current_user.obj.userprofile.gym_id %}
+                <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
+                    {{ current_user.obj.userprofile.gym }}
+                </a>
+                {% else %}
+                -/-
+                {% endif %}
+            </td>
+            {% endif %}
+        </tr>
+        {% endfor %}
+    </tbody>
 </table>

--- a/wger/gym/views/gym.py
+++ b/wger/gym/views/gym.py
@@ -193,11 +193,15 @@ class GymUserListView(LoginRequiredMixin, WgerMultiplePermissionRequiredMixin, L
         Return a list with the users, not really a queryset.
         '''
         out = {'admins': [],
-               'members': []}
+               'members': [],
+               'inactive_members': []}
 
         for u in Gym.objects.get_members(self.kwargs['pk']).select_related('usercache'):
             out['members'].append({'obj': u,
                                    'last_log': u.usercache.last_activity})
+        for u in Gym.objects.get_members(self.kwargs['pk'], active=0).select_related('usercache'):
+            out['inactive_members'].append({'obj': u,
+                                            'last_log': u.usercache.last_activity})
 
         # admins list
         for u in Gym.objects.get_admins(self.kwargs['pk']):
@@ -219,6 +223,11 @@ class GymUserListView(LoginRequiredMixin, WgerMultiplePermissionRequiredMixin, L
         context['user_count'] = len(context['object_list']['members'])
         context['user_table'] = {'keys': [_('ID'), _('Username'), _('Name'), _('Last activity')],
                                  'users': context['object_list']['members']}
+        context['inactive_users_count'] = len(context['object_list']['inactive_members'])
+        context['inactive_users_table'] = {'keys': [
+            _('ID'), _('Username'), _('Name'), _('Last activity')],
+            'users': context['object_list']['inactive_members']
+        }
         return context
 
 


### PR DESCRIPTION
#### Title
User should be able to view a list of deactivated Gym members in the gym overvies
<!-- A short description of what needs to be done. -->

#### Description
This allows gym managers and Admins be able to view the list of deactivated members for gyms
<!-- Why is it needed? Does it help the team go faster or is it a dependency that could cause problems in the codebase if it’s not done? -->

<!-- Note: Every story title should include the word ‘should’ as opposed to ‘can’. e.g. It’s unclear whether the story “User can delete comment” is a feature or a bug. “User should be able to delete comment” or “User should not be able to delete comment” are much clearer: the former is a feature, the latter a bug. -->

#### How Can This Be Tested?
To be able to test the feature, check out the branch `story/166152317-list-deactivated-gym-users` and then `python manage.py runserver`.
Navigate to the URL `http://127.0.0.1:8000/en/gym/<gym_id>/members` on your browser
Add users to the gym, select a user and deactivate or set some users is_active db field to False or 0
On Postgres CMD use
`UPDATE auth_user
SET is_active=False
WHERE id=<user_id>;`
![image](https://user-images.githubusercontent.com/12586916/59301783-17492580-8c9b-11e9-8ea2-643e919f2d12.png)


*Inactive members*
![image](https://user-images.githubusercontent.com/12586916/59302354-79565a80-8c9c-11e9-9cb0-6280ae5f65c2.png)



#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue) 

- [x] New feature (non-breaking change which adds functionality) 


- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) 


- [ ] This change requires a documentation update



#### Checklist:
- [x] gym overview page to list deactivated gym members 

#### PT stories
[#166152317](https://www.pivotaltracker.com/story/show/166152317)
<!-- [delivers #166152317] -->