### PR TITLE
166152323 reset cache on muscle delete

### DIFF
--- a/wger/exercises/signals.py
+++ b/wger/exercises/signals.py
@@ -16,13 +16,38 @@
 
 
 from django.db.models.signals import pre_save
-from django.db.models.signals import post_delete
+from django.db.models.signals import (post_delete, post_save)
 from django.dispatch import receiver
+
 from easy_thumbnails.files import get_thumbnailer
 from easy_thumbnails.signal_handlers import generate_aliases
 from easy_thumbnails.signals import saved_file
 
-from wger.exercises.models import ExerciseImage
+from wger.exercises.models import ExerciseImage, Muscle
+from wger.core.models import Language
+
+
+from wger.utils.cache import (
+    delete_template_fragment_cache,
+)
+
+
+def delete_muscle_overview_template():
+    """
+    this function deletes the muscle overview template in all the languages
+    """
+    for language in Language.objects.all():
+        delete_template_fragment_cache('muscle-overview', language.id)
+
+
+@receiver(post_delete, sender=Muscle)
+def update_cache_on_muscle_delete(sender, instance, *args, **kwargs):
+    delete_muscle_overview_template()
+
+
+@receiver(post_save, sender=Muscle)
+def update_cache_on_muscle_save(sender, *args, **kwargs):
+    delete_muscle_overview_template()
 
 
 @receiver(post_delete, sender=ExerciseImage)

--- a/wger/exercises/templates/muscles/overview.html
+++ b/wger/exercises/templates/muscles/overview.html
@@ -12,10 +12,10 @@
 <script src="{% static 'js/svg.js' %}"></script>
 
 <script>
-$(document).ready(function() {
-    //Prefetch the background images
-    {% for muscle in muscle_list|first %}
-        wgerPrefetchImages(['/static/images/muscles/main/muscle-' + {{muscle.id}} + '.svg']);
+    $(document).ready(function () {
+        //Prefetch the background images
+        {% for muscle in muscle_list %}
+        wgerPrefetchImages(['/static/images/muscles/main/muscle-' + {{ muscle.id }} + '.svg']);
     {% endfor %}
     wgerPrefetchImages(['/static/images/muscles/muscular_system_back.svg']);
     $('#muscle-systems').append(front_muscles);
@@ -23,7 +23,7 @@ $(document).ready(function() {
     // Hightlight the first element
     wgerHighlightMuscle($('.muscle').first());
     // Highlight on hover
-    $('.muscle').hover(function(e) {
+    $('.muscle').hover(function (e) {
         e.preventDefault();
         wgerHighlightMuscle(this);
         //load front muscles if front
@@ -88,45 +88,42 @@ $(document).ready(function() {
 
     <div class="col-sm-4 col-xs-6">
         {# Why do we need to use |first? #}
-        {% regroup muscle_list|first by is_front as muscle_group %}
+        {% regroup muscle_list by is_front as muscle_group %}
         {% for group in muscle_group %}
-            {% if group.grouper %}
-                <h4>{% trans "Front side" %}</h4>
-            {% else %}
-                <h4>{% trans "Back side" %}</h4>
-            {% endif %}
+        {% if group.grouper %}
+        <h4>{% trans "Front side" %}</h4>
+        {% else %}
+        <h4>{% trans "Back side" %}</h4>
+        {% endif %}
 
-            <ul class="muscle-list">
+        <ul class="muscle-list">
             {% for muscle in group.list %}
-            <li class="muscle"
-                data-target="muscle-{{muscle.id}}"
-                data-is-front="{{muscle.is_front}}"
-                data-name="{{muscle.name}}"
-                itemscope itemtype="http://schema.org/Muscle">
+            <li class="muscle" data-target="muscle-{{muscle.id}}" data-is-front="{{muscle.is_front}}"
+                data-name="{{muscle.name}}" itemscope itemtype="http://schema.org/Muscle">
                 <span itemprop="name">{{muscle.name}}</span>
             </li>
             {% endfor %}
-            </ul>
+        </ul>
         {% endfor %}
     </div>
     <div class="col-sm-4 col-xs-12">
-        {% for muscle in muscle_list|first %}
-            <div id="muscle-{{muscle.id}}" style="display:none;" class="exercise-list">
-                <h4>{% trans "Exercises" %}</h4>
-                <ul class="exercise-overview">
-                    {% for exercise in muscle.exercise_set.select_related %}
-                    {% if exercise.language in active_languages %}
-                    <li class="exercise">
-                        <a href="{{exercise.get_absolute_url}}">{{exercise}}</a>
-                    </li>
-                    {% endif %}
-                    {% empty %}
-                    <li>
-                        <em>{% trans "No exercises that mainly train this muscle" %}</em>
-                    </li>
-                    {% endfor %}
-                </ul>
-            </div>
+        {% for muscle in muscle_list %}
+        <div id="muscle-{{muscle.id}}" style="display:none;" class="exercise-list">
+            <h4>{% trans "Exercises" %}</h4>
+            <ul class="exercise-overview">
+                {% for exercise in muscle.exercise_set.select_related %}
+                {% if exercise.language in active_languages %}
+                <li class="exercise">
+                    <a href="{{exercise.get_absolute_url}}">{{exercise}}</a>
+                </li>
+                {% endif %}
+                {% empty %}
+                <li>
+                    <em>{% trans "No exercises that mainly train this muscle" %}</em>
+                </li>
+                {% endfor %}
+            </ul>
+        </div>
         {% endfor %}
     </div>
 </div>

--- a/wger/exercises/views/muscles.py
+++ b/wger/exercises/views/muscles.py
@@ -43,7 +43,7 @@ class MuscleListView(ListView):
     Overview of all muscles and their exercises
     '''
     model = Muscle
-    queryset = Muscle.objects.all().order_by('-is_front', 'name'),
+    queryset = Muscle.objects.all().order_by('-is_front', 'name')
     context_object_name = 'muscle_list'
     template_name = 'muscles/overview.html'
 


### PR DESCRIPTION
#### Title
<!-- A short description of what needs to be done. -->
Resetting cache on muscle delete

#### Description
Initially, after deleting a muscle, it still appeared under the muscle overview page. This was caused by a failure to reset muscle cache on delete.
The cache should be reset after a muscle has been deleted such that the deleted muscle in not visible from the exercises page.
#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue) 

- [ ] New feature (non-breaking change which adds functionality) 


- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) 


- [ ] This change requires a documentation update


#### How Has This Been Tested?
-Log in to the application as an admin, visit the muscle menu under the exercise tab
`localhost:8000/en/exercise/muscle/admin-overview/`
-Click on the add muscle button and add a muscle name.
-Visit the add exercise tab and add a new exercise focusing on the new muscle added.
-Go back to the muscles menu and delete the recently added muscle and verify that the muscle no-longer included under the muscle overview page.

#### Checklist:

- [x] - create a signal on muscle delete to delete the muscle overview page cache
- [x] - create a signal on muscle creation to delete the overview page cache
- [x] - create a reusable function to delete the overview page cache on muscle deletion and creation



#### PT stories
[#166152323](https://www.pivotaltracker.com/n/projects/2350046/stories/166152323)