### PR TITLE
166152318 cache nutritional values

### DIFF
--- a/wger/nutrition/__init__.py
+++ b/wger/nutrition/__init__.py
@@ -19,3 +19,4 @@
 from wger import get_version
 
 VERSION = get_version()
+default_app_config = 'wger.nutrition.apps.NutritionPlanConfig'

--- a/wger/nutrition/apps.py
+++ b/wger/nutrition/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class NutritionPlanConfig(AppConfig):
+    name = 'wger.nutrition'
+    verbose_name = 'nutrition'
+
+    def ready(self):
+        import wger.nutrition.signals  # noqa

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -41,6 +41,7 @@ from wger.utils.models import AbstractLicenseModel
 from wger.utils.units import AbstractWeight
 from wger.weight.models import WeightEntry
 
+
 MEALITEM_WEIGHT_GRAM = '1'
 MEALITEM_WEIGHT_UNIT = '2'
 
@@ -110,47 +111,51 @@ class NutritionPlan(models.Model):
         Sums the nutritional info of all items in the plan
         '''
         use_metric = self.user.userprofile.use_metric
-        unit = 'kg' if use_metric else 'lb'
-        result = {'total': {'energy': 0,
-                            'protein': 0,
-                            'carbohydrates': 0,
-                            'carbohydrates_sugar': 0,
-                            'fat': 0,
-                            'fat_saturated': 0,
-                            'fibres': 0,
-                            'sodium': 0},
-                  'percent': {'protein': 0,
-                              'carbohydrates': 0,
-                              'fat': 0},
-                  'per_kg': {'protein': 0,
-                             'carbohydrates': 0,
-                             'fat': 0},
-                  }
+        result = cache.get(cache_mapper.get_nutritional_values(self.pk))
+        if not result:
+            unit = 'kg' if use_metric else 'lb'
+            result = {'total': {'energy': 0,
+                                'protein': 0,
+                                'carbohydrates': 0,
+                                'carbohydrates_sugar': 0,
+                                'fat': 0,
+                                'fat_saturated': 0,
+                                'fibres': 0,
+                                'sodium': 0},
+                      'percent': {'protein': 0,
+                                  'carbohydrates': 0,
+                                  'fat': 0},
+                      'per_kg': {'protein': 0,
+                                 'carbohydrates': 0,
+                                 'fat': 0},
+                      }
 
-        # Energy
-        for meal in self.meal_set.select_related():
-            values = meal.get_nutritional_values(use_metric=use_metric)
-            for key in result['total'].keys():
-                result['total'][key] += values[key]
+            # Energy
+            for meal in self.meal_set.select_related():
+                values = meal.get_nutritional_values(use_metric=use_metric)
+                for key in result['total'].keys():
+                    result['total'][key] += values[key]
 
-        energy = result['total']['energy']
+            energy = result['total']['energy']
 
-        # In percent
-        if energy:
-            for key in result['percent'].keys():
-                result['percent'][key] = \
-                    result['total'][key] * ENERGY_FACTOR[key][unit] / energy * 100
+            # In percent
+            if energy:
+                for key in result['percent'].keys():
+                    result['percent'][key] = \
+                        result['total'][key] * ENERGY_FACTOR[key][unit] / energy * 100
 
-        # Per body weight
-        weight_entry = self.get_closest_weight_entry()
-        if weight_entry:
-            for key in result['per_kg'].keys():
-                result['per_kg'][key] = result['total'][key] / weight_entry.weight
+            # Per body weight
+            weight_entry = self.get_closest_weight_entry()
+            if weight_entry:
+                for key in result['per_kg'].keys():
+                    result['per_kg'][key] = result['total'][key] / weight_entry.weight
 
-        # Only 2 decimal places, anything else doesn't make sense
-        for key in result.keys():
-            for i in result[key]:
-                result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
+            # Only 2 decimal places, anything else doesn't make sense
+            for key in result.keys():
+                for i in result[key]:
+                    result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
+            # set the cache after loading the data from the queries.
+            cache.set(cache_mapper.get_nutritional_values(self.pk), result)
 
         return result
 
@@ -395,7 +400,7 @@ class Ingredient(AbstractLicenseModel, models.Model):
         if isinstance(other, self.__class__):
             for i in self._meta.fields:
                 if (hasattr(self, i.name) and hasattr(other, i.name)
-                   and(getattr(self, i.name, None) != getattr(other, i.name, None))):
+                        and(getattr(self, i.name, None) != getattr(other, i.name, None))):
                     equal = False
         else:
             equal = False

--- a/wger/nutrition/signals.py
+++ b/wger/nutrition/signals.py
@@ -1,0 +1,26 @@
+from django.db.models.signals import (post_save, post_delete)
+from django.dispatch import receiver
+from wger.nutrition.models import (NutritionPlan, Meal, MealItem)
+from wger.utils.cache import reset_nutritional_values
+
+
+@receiver(post_save, sender=NutritionPlan)
+@receiver(post_save, sender=Meal)
+@receiver(post_save, sender=MealItem)
+@receiver(post_delete, sender=NutritionPlan)
+@receiver(post_delete, sender=Meal)
+@receiver(post_delete, sender=MealItem)
+def delete_cache(sender, **kwargs):
+    """
+    deletes the cache when either of the above signals
+    are hit
+    """
+    model_instance = kwargs['instance']
+    if sender == NutritionPlan:
+        pk = model_instance.pk
+    elif sender == Meal:
+        pk = model_instance.plan.pk
+    elif sender == MealItem:
+        pk = model_instance.meal.plan.pk
+
+    reset_nutritional_values(pk)

--- a/wger/nutrition/tests/test_nutritional_values_cache.py
+++ b/wger/nutrition/tests/test_nutritional_values_cache.py
@@ -1,0 +1,43 @@
+from django.core.cache import cache
+from wger.utils.cache import cache_mapper
+from wger.core.tests.base_testcase import WorkoutManagerTestCase
+from wger.nutrition.models import NutritionPlan
+
+
+class NutritionInfoCacheTestCase(WorkoutManagerTestCase):
+    '''
+    Test case for the nutrition info caching
+    '''
+
+    def test_meal_nutritional_info_cache(self):
+        '''
+        Tests that the nutrition cache of the canonical form is
+        correctly generated
+        '''
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_values(1)))
+
+        plan = NutritionPlan.objects.get(pk=1)
+        plan.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_values(1)))
+
+    def test_nutrition_info_cache_save(self):
+        '''
+        Tests nutritional info cache when saving / updating
+        '''
+        plan = NutritionPlan.objects.get(pk=1)
+        plan.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_values(1)))
+
+        plan.save()
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_values(1)))
+
+    def test_nutrition_info_cache_delete(self):
+        '''
+        Tests the nutritional info cache when deleting
+        '''
+        plan = NutritionPlan.objects.get(pk=1)
+        plan.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_values(1)))
+
+        plan.delete()
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_values(1)))

--- a/wger/utils/cache.py
+++ b/wger/utils/cache.py
@@ -55,6 +55,13 @@ def reset_workout_log(user_pk, year, month, day=None):
     cache.delete(cache_mapper.get_workout_log_list(log_hash))
 
 
+def reset_nutritional_values(value_id):
+    """
+        reset the nutrition cache
+    """
+    cache.delete(cache_mapper.get_nutritional_values(value_id))
+
+
 class CacheKeyMapper(object):
     '''
     Simple class for mapping the cache keys of different objects
@@ -67,6 +74,7 @@ class CacheKeyMapper(object):
     INGREDIENT_CACHE_KEY = 'ingredient-{0}'
     WORKOUT_CANONICAL_REPRESENTATION = 'workout-canonical-representation-{0}'
     WORKOUT_LOG_LIST = 'workout-log-hash-{0}'
+    NUTRITIONAL_CACHE_KEY = 'nutritional-plan-{0}'
 
     def get_pk(self, param):
         '''
@@ -114,6 +122,12 @@ class CacheKeyMapper(object):
         Return the workout canonical representation
         '''
         return self.WORKOUT_LOG_LIST.format(hash_value)
+
+    def get_nutritional_values(self, param):
+        '''
+        Returns the nutritional information
+        '''
+        return self.NUTRITIONAL_CACHE_KEY.format(self.get_pk(param))
 
 
 cache_mapper = CacheKeyMapper()


### PR DESCRIPTION
#### Title
<!-- A short description of what needs to be done. -->
Cache nutritional values for a plan

#### Description
<!-- Why is it needed? Does it help the team go faster or is it a dependency that could cause problems in the codebase if it’s not done? -->

<!-- Note: Every story title should include the word ‘should’ as opposed to ‘can’. e.g. It’s unclear whether the story “User can delete comment” is a feature or a bug. “User should be able to delete comment” or “User should not be able to delete comment” are much clearer: the former is a feature, the latter a bug. -->

The nutritional information should be cached so as to reduce the number of db queries that may slow down the rendering process. The cache should be deleted once a nutrition plan, meal or meal item is added, deleted or edited.

The following pages that are affected by the new change for the better since they will be retrieving the nutrition data from the cache once a plan is viewed.

`http://localhost:8000/en/nutrition/<nutritionId>/view`

`http://localhost:8000/en/user/<userId>/overview`



#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue) 

- [x] New feature (non-breaking change which adds functionality) 


- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) 


- [ ] This change requires a documentation update


#### How Has This Been Tested?
- [x] Unit tests

#### Checklist:

 - [x] - create signals for cache deletion
           
  - [x] - create functionality to save nutritional info to cache
           
   - [x] - create tests for saving info to cache

#### PT stories
[#166152318](https://www.pivotaltracker.com/n/projects/2350046/stories/166152318)