### PR TITLE
166152324 Allow users to select language for Ingredients and exercise

### DIFF
--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -38,7 +38,7 @@ $(document).ready(function() {
 -->
 {% block content %}
 
-{% cache cache_timeout exercise-overview language.id %}
+{% cache 1 exercise-overview language.id %}
 {% regroup exercises by category as exercise_list %}
 <ul class="nav nav-tabs">
     {% for item in exercise_list %}
@@ -112,6 +112,20 @@ $(document).ready(function() {
            id="exercise-search"
            class="ajax-form-element form-control"
            placeholder="{% trans 'exercise name' %}">
+
+<br/>
+<h4> {% trans "Select language" %}</h4>
+    <button id="filter" class="btn btn-sm btn-primary dropdown-toggle" data-toggle="dropdown">
+        {% trans "Choose language" %}
+    </button>
+    <ul class="dropdown-menu" role="menu" style="float:right;">
+        <li><a href={% url 'exercise:exercise:overview' %}>{% trans "Default" %}</a></li>
+
+        {% for  short_name, long_name in languages %}
+        <li><a href={% url 'exercise:exercise:overview' %}?language={{ short_name }}>{% trans long_name %}</a></li>
+        {% endfor %}
+    </ul>
+
 {% endblock %}
 
 

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -513,6 +513,21 @@ class WorkoutCacheTestCase(WorkoutManagerTestCase):
             self.assertFalse(cache.get(cache_mapper.get_workout_canonical(workout_id)))
 
 
+class ExerciseLanguageTestCase(WorkoutManagerTestCase):
+    '''
+        Tests that correct language is loaded.
+    '''
+
+    def test_exercise_language(self):
+        '''
+        Tests language of the exercise
+        '''
+        url = reverse('exercise:exercise:overview') + '?language=de'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['active_tab'], 'exercises')
+
+
 # TODO: fix test, all registered users can upload exercises
 # class ExerciseApiTestCase(api_base_test.ApiBaseResourceTestCase):
 #     '''

--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -58,6 +58,7 @@ from wger.utils.widgets import (
     TranslatedOriginalSelectMultiple
 )
 from wger.config.models import LanguageConfig
+from wger.core.models import Language
 from wger.weight.helpers import process_log_entries
 
 
@@ -77,7 +78,21 @@ class ExerciseListView(ListView):
         '''
         Filter to only active exercises in the configured languages
         '''
+        # get default local language.
         languages = load_item_languages(LanguageConfig.SHOW_ITEM_EXERCISES)
+
+        # let user select a language they want to view exercises in.
+        selected_language = self.request.GET.get('language', None)
+        language = None
+
+        if selected_language:
+            language = Language.objects.filter(short_name=selected_language).first().id
+
+            # Load selected language
+            return Exercise.objects.accepted().filter(language=language) \
+                .order_by('category__id').select_related()
+
+        # Load default langauge
         return Exercise.objects.accepted() \
             .filter(language__in=languages) \
             .order_by('category__id') \

--- a/wger/nutrition/templates/ingredient/overview.html
+++ b/wger/nutrition/templates/ingredient/overview.html
@@ -70,6 +70,19 @@
                placeholder="{% trans 'ingredient name' %}"
                style="width:100%;">
     </form>
+
+    <br/>
+    <h4> {% trans "Select language" %}</h4>
+        <button id="filter-language" class="btn btn-sm btn-primary dropdown-toggle" data-toggle="dropdown">
+            {% trans "Choose Language" %}
+        </button>
+        <ul class="dropdown-menu" role="menu" style="float:right;">
+            <li><a href={% url 'nutrition:ingredient:list' %}>{% trans "Default" %}</a></li>
+
+            {% for  short_name, long_name in languages %}
+            <li><a href={% url 'nutrition:ingredient:list' %}?language={{ short_name }}>{% trans long_name %}</a></li>
+            {% endfor %}
+        </ul>
 {% endblock %}
 
 

--- a/wger/nutrition/tests/test_ingredient.py
+++ b/wger/nutrition/tests/test_ingredient.py
@@ -347,6 +347,21 @@ class IngredientTestCase(WorkoutManagerTestCase):
         self.assertRaises(ValidationError, ingredient.full_clean)
 
 
+class IngredientLanguageTestCase(WorkoutManagerTestCase):
+    '''
+        Tests ingredients are loaded with right language.
+    '''
+
+    def test_ingredients_language(self):
+        '''
+        Tests language of the ingredients
+        '''
+        url = reverse('nutrition:ingredient:list') + '?language=de'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['active_tab'], 'nutrition')
+
+
 class IngredientApiTestCase(api_base_test.ApiBaseResourceTestCase):
     '''
     Tests the ingredient API resource

--- a/wger/nutrition/views/ingredient.py
+++ b/wger/nutrition/views/ingredient.py
@@ -33,6 +33,7 @@ from django.views.generic import (
 
 from wger.nutrition.forms import UnitChooserForm
 from wger.nutrition.models import Ingredient
+from wger.core.models import Language
 from wger.utils.generic_views import (
     WgerFormMixin,
     WgerDeleteMixin
@@ -64,7 +65,21 @@ class IngredientListView(ListView):
         (the user can also want to see ingredients in English, in addition to his
         native language, see load_ingredient_languages)
         '''
+        # get default language.
         languages = load_ingredient_languages(self.request)
+
+        # let user select a language they want to view in.
+        selected_language = self.request.GET.get('language', None)
+        language = None
+
+        if selected_language:
+            language = Language.objects.filter(short_name=selected_language).first().id
+
+            # Load selected language
+            return Ingredient.objects.filter(language=language) \
+                .filter(status__in=Ingredient.INGREDIENT_STATUS_OK).only('id', 'name')
+
+        # loads the default language if no language is selected.
         return (Ingredient.objects.filter(language__in=languages)
                                   .filter(status__in=Ingredient.INGREDIENT_STATUS_OK)
                                   .only('id', 'name'))


### PR DESCRIPTION
#### Title
Allow users to choose which languages they want to view exercises and ingredients in.

#### Description
Users should be able to select a language from a dropdown menu with which they would be able to view ingredients and exercises.

**To test this**
1. Check out the branch `story/166152324-make-translations-easier`
2. Run `python manage.py runserver`
3 Navigate to `/en/exercise/overview` and  `/en/nutrition/ingredient/overview/`
4 Select language from the dropdown menu on the right

<img width="1440" alt="Screenshot 2019-06-18 at 14 13 38" src="https://user-images.githubusercontent.com/40719885/59713284-bdef7200-9217-11e9-8aca-2bdcb7f75297.png">

<img width="1440" alt="Screenshot 2019-06-18 at 14 13 56" src="https://user-images.githubusercontent.com/40719885/59713325-d52e5f80-9217-11e9-8760-5e188ccbc738.png">


#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue) 

- [x] New feature (non-breaking change which adds functionality) 


- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) 


- [ ] This change requires a documentation update



#### Checklist:

- [x] Add support for drop-down lists for languages on both exercises and ingredients overview page
- [x] Update views to allow change of language when filtering through the languages

#### PT stories
[#166152324](https://www.pivotaltracker.com/story/show/166152324)